### PR TITLE
Type `this` parameter for DefineActions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { ActionContext as BaseActionContext } from 'vuex'
+import { ActionContext as BaseActionContext, Store } from 'vuex'
 
 import './helpers'
 
@@ -52,6 +52,7 @@ export type DefineActions<
   ExtraActions = {}
 > = {
   [K in keyof Actions]: (
+    this: Store<State>,
     ctx: ActionContext<State, Getters, Actions & ExtraActions, Mutations>,
     payload: Actions[K]
   ) => void | Promise<any>


### PR DESCRIPTION
This change fixes to treat `this` as `Store` instance inside actions. This definition matches to [the official definition](https://github.com/vuejs/vuex/blob/0e109e2a38dafdc0c2bd6bd3892bc66cfe252b16/types/index.d.ts#L100).

Motivation: Some nuxt plugins, e.g. [@nuxtjs/axios](https://github.com/nuxt-community/axios-module/blob/1ed6e2ffef6ac91fd2fdd4f4cbdfface8da1b2f4/types/vuex.d.ts#L5) , inject properties to `Store` instance and `Store` type is redefined to access them. Unfortunately, current definition treats `this` as `{}` and they cannot be accessed in TypeScript.