### PR TITLE
fix: Defining types for functions without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ export interface CounterMutations {
   inc: {
     amount: number
   }
+  reset: undefined // having no payload
 }
 
 export interface CounterActions {
@@ -43,6 +44,7 @@ export interface CounterActions {
     amount: number
     delay: number
   }
+  reset: undefined // having no payload
 }
 
 /**
@@ -59,6 +61,10 @@ const getters: DefineGetters<CounterGetters, CounterState> = {
 const mutations: DefineMutations<CounterMutations, CounterState> = {
   inc (state, { amount }) {
     state.count += amount
+  },
+
+  reset(state) {
+    state.count = 0
   }
 }
 
@@ -67,6 +73,10 @@ const actions: DefineActions<CounterActions, CounterState, CounterMutations, Cou
     setTimeout(() => {
       commit('inc', payload)
     }, payload.delay)
+  },
+
+  reset({ commit }) {
+    commit('reset')
   }
 }
 
@@ -89,9 +99,17 @@ store.dispatch<Dispatcher<CounterActions>>({
   delay: 1000
 })
 
+store.dispatch<Dispatcher<CounterActions>>({
+  type: 'reset'
+})
+
 store.commit<Committer<CounterMutations>>({
   type: 'inc',
   amount: 1
+})
+
+store.commit<Committer<CounterMutations>>({
+  type: 'reset'
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export interface CounterMutations {
   inc: {
     amount: number
   }
-  reset: undefined // having no payload
+  reset: void // having no payload
 }
 
 export interface CounterActions {
@@ -44,7 +44,7 @@ export interface CounterActions {
     amount: number
     delay: number
   }
-  reset: undefined // having no payload
+  reset: void // having no payload
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,8 @@ interface RootOption {
   root: true
 }
 
-type PayloadArgs<T> = T extends undefined ? [] : [T]
-type PayloadForWithType<T> = T extends undefined ? {} : T
+type PayloadArgs<T> = T extends void ? [] : [T]
+type PayloadForWithType<T> = T extends void ? {} : T
 
 interface Dispatch<P> {
   <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): Promise<any>

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,10 +11,11 @@ interface RootOption {
 }
 
 type PayloadArgs<T> = T extends undefined ? [] : [T]
+type PayloadForWithType<T> = T extends undefined ? {} : T
 
 interface Dispatch<P> {
   <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): Promise<any>
-  <K extends keyof P>(payloadWithType: { type: K } & P[K]): Promise<any>
+  <K extends keyof P>(payloadWithType: { type: K } & PayloadForWithType<P[K]>): Promise<any>
 
   // Fallback for root actions
   (type: string, payload: any, options: RootOption): Promise<any>
@@ -23,7 +24,7 @@ interface Dispatch<P> {
 
 interface Commit<P> {
   <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): void
-  <K extends keyof P>(payloadWithType: { type: K } & P[K]): void
+  <K extends keyof P>(payloadWithType: { type: K } & PayloadForWithType<P[K]>): void
 
   // Fallback for root mutations
   (type: string, payload: any, options: RootOption): void
@@ -64,7 +65,7 @@ export type DefineMutations<Mutations, State> = {
   [K in keyof Mutations]: (state: State, payload: Mutations[K]) => void
 }
 
-type Mapper<P> = { [K in keyof P]: { type: K } & P[K] }
+type Mapper<P> = { [K in keyof P]: { type: K } & PayloadForWithType<P[K]> }
 
 export type Dispatcher<
   Actions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,10 @@ interface RootOption {
   root: true
 }
 
+type PayloadArgs<T> = T extends undefined ? [] : [T]
+
 interface Dispatch<P> {
-  <K extends keyof P>(type: K, payload: P[K]): Promise<any>
+  <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): Promise<any>
   <K extends keyof P>(payloadWithType: { type: K } & P[K]): Promise<any>
 
   // Fallback for root actions
@@ -20,7 +22,7 @@ interface Dispatch<P> {
 }
 
 interface Commit<P> {
-  <K extends keyof P>(type: K, payload: P[K]): void
+  <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): void
   <K extends keyof P>(payloadWithType: { type: K } & P[K]): void
 
   // Fallback for root mutations

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -44,6 +44,7 @@ interface FooActions {
   baz: {
     qux: number
   }
+  actionWithoutPayload: undefined
 }
 
 interface FooMutations {
@@ -53,6 +54,7 @@ interface FooMutations {
   hello: {
     world: string
   }
+  mutationWithoutPayload: undefined
 }
 
 /**
@@ -89,6 +91,8 @@ const actions: DefineActions<
     ctx.dispatch({ type: 'foo', bar: 1 })
     ctx.dispatch('baz', { qux: 1 })
     ctx.dispatch({ type: 'baz', qux: 1 })
+    ctx.dispatch('actionWithoutPayload')
+    ctx.dispatch({ type: 'actionWithoutPayload' })
 
     // dispatch outer actions
     ctx.dispatch('test', 'value')
@@ -99,6 +103,8 @@ const actions: DefineActions<
     ctx.commit({ type: 'test', value: '123' })
     ctx.commit('hello', { world: '123' })
     ctx.commit({ type: 'hello', world: '123' })
+    ctx.commit('mutationWithoutPayload')
+    ctx.commit({ type: 'mutationWithoutPayload' })
 
     // commit outer mutations
     ctx.commit('inc', 123)
@@ -119,6 +125,10 @@ const actions: DefineActions<
     ctx.getters.def
 
     payload.qux
+  },
+
+  actionWithoutPayload(ctx) {
+    ctx.state.value
   }
 }
 
@@ -131,6 +141,10 @@ const mutations: DefineMutations<FooMutations, FooState> = {
 
   hello(state, payload) {
     payload.world
+  },
+
+  mutationWithoutPayload(state) {
+    state.value
   }
 }
 
@@ -152,7 +166,15 @@ store.dispatch<Dispatcher<FooActions>>({
   bar: 123
 })
 
+store.dispatch<Dispatcher<FooActions>>({
+  type: 'actionWithoutPayload'
+})
+
 store.commit<Committer<FooMutations>>({
   type: 'test',
   value: ''
+})
+
+store.commit<Committer<FooMutations>>({
+  type: 'mutationWithoutPayload',
 })

--- a/test/counter.ts
+++ b/test/counter.ts
@@ -24,7 +24,7 @@ export interface CounterMutations {
   inc: {
     amount: number
   }
-  reset: undefined // having no payload
+  reset: void // having no payload
 }
 
 export interface CounterActions {
@@ -33,7 +33,7 @@ export interface CounterActions {
     amount: number
     delay: number
   }
-  reset: undefined // having no payload
+  reset: void // having no payload
 }
 
 /**

--- a/test/counter.ts
+++ b/test/counter.ts
@@ -24,6 +24,7 @@ export interface CounterMutations {
   inc: {
     amount: number
   }
+  reset: undefined // having no payload
 }
 
 export interface CounterActions {
@@ -32,6 +33,7 @@ export interface CounterActions {
     amount: number
     delay: number
   }
+  reset: undefined // having no payload
 }
 
 /**
@@ -48,6 +50,10 @@ const getters: DefineGetters<CounterGetters, CounterState> = {
 const mutations: DefineMutations<CounterMutations, CounterState> = {
   inc(state, { amount }) {
     state.count += amount
+  },
+
+  reset(state) {
+    state.count = 0
   }
 }
 
@@ -61,6 +67,10 @@ const actions: DefineActions<
     setTimeout(() => {
       commit('inc', payload)
     }, payload.delay)
+  },
+
+  reset({ commit }) {
+    commit('reset')
   }
 }
 
@@ -83,7 +93,15 @@ store.dispatch<Dispatcher<CounterActions>>({
   delay: 1000
 })
 
+store.dispatch<Dispatcher<CounterActions>>({
+  type: 'reset'
+})
+
 store.commit<Committer<CounterMutations>>({
   type: 'inc',
   amount: 1
+})
+
+store.commit<Committer<CounterMutations>>({
+  type: 'reset'
 })


### PR DESCRIPTION
fix: https://github.com/ktsn/vuex-type-helper/issues/6

Hi, I know this library is PoC, but I use this because it's powerful :)

- https://twitter.com/ktsn/status/1095945466276020224
- https://twitter.com/ktsn/status/1072893489912762368

```
// test/basic.ts 

ctx.dispatch('actionWithoutPayload') // passes
ctx.dispatch({ type: 'actionWithoutPayload' }) // passes

ctx.commit('mutationWithoutPayload') // passes
ctx.commit({ type: 'mutationWithoutPayload' }) // passes
```    
