### PR TITLE
fix: errors of defining types for functions with union type payloads

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ type PayloadForWithType<T> = T extends void ? {} : T
 
 interface Dispatch<P> {
   <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): Promise<any>
+  <K extends keyof P>(type: K, payload: P[K]): Promise<any> // Fallback for union type payload
   <K extends keyof P>(payloadWithType: { type: K } & PayloadForWithType<P[K]>): Promise<any>
 
   // Fallback for root actions
@@ -24,6 +25,7 @@ interface Dispatch<P> {
 
 interface Commit<P> {
   <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): void
+  <K extends keyof P>(type: K, payload: P[K]): void // Fallback for union type payload
   <K extends keyof P>(payloadWithType: { type: K } & PayloadForWithType<P[K]>): void
 
   // Fallback for root mutations

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,12 +10,11 @@ interface RootOption {
   root: true
 }
 
-type PayloadArgs<T> = T extends void ? [] : [T]
+type PayloadArgs<T> = [T] extends [void] ? [] : [T]
 type PayloadForWithType<T> = T extends void ? {} : T
 
 interface Dispatch<P> {
   <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): Promise<any>
-  <K extends keyof P>(type: K, payload: P[K]): Promise<any> // Fallback for union type payload
   <K extends keyof P>(payloadWithType: { type: K } & PayloadForWithType<P[K]>): Promise<any>
 
   // Fallback for root actions
@@ -25,7 +24,6 @@ interface Dispatch<P> {
 
 interface Commit<P> {
   <K extends keyof P>(type: K, ...payloadArgs: PayloadArgs<P[K]>): void
-  <K extends keyof P>(type: K, payload: P[K]): void // Fallback for union type payload
   <K extends keyof P>(payloadWithType: { type: K } & PayloadForWithType<P[K]>): void
 
   // Fallback for root mutations

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -45,7 +45,7 @@ interface FooActions {
     qux: number
   }
   actionWithUnionPayload: 'active' | 'inactive'
-  actionWithoutPayload: undefined
+  actionWithoutPayload: void
 }
 
 interface FooMutations {
@@ -56,7 +56,7 @@ interface FooMutations {
     world: string
   }
   mutationWithUnionPayload: 'active' | 'inactive'
-  mutationWithoutPayload: undefined
+  mutationWithoutPayload: void
 }
 
 /**

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -44,6 +44,7 @@ interface FooActions {
   baz: {
     qux: number
   }
+  actionWithUnionPayload: 'active' | 'inactive'
   actionWithoutPayload: undefined
 }
 
@@ -54,6 +55,7 @@ interface FooMutations {
   hello: {
     world: string
   }
+  mutationWithUnionPayload: 'active' | 'inactive'
   mutationWithoutPayload: undefined
 }
 
@@ -91,6 +93,13 @@ const actions: DefineActions<
     ctx.dispatch({ type: 'foo', bar: 1 })
     ctx.dispatch('baz', { qux: 1 })
     ctx.dispatch({ type: 'baz', qux: 1 })
+
+    const getStatus = (): 'active' | 'inactive' => {
+      const statusArray = ['active', 'inactive'] as ['active', 'inactive']
+      return statusArray[Math.floor(Math.random() * statusArray.length)]
+    }
+    ctx.dispatch('actionWithUnionPayload', getStatus())
+
     ctx.dispatch('actionWithoutPayload')
     ctx.dispatch({ type: 'actionWithoutPayload' })
 
@@ -103,6 +112,7 @@ const actions: DefineActions<
     ctx.commit({ type: 'test', value: '123' })
     ctx.commit('hello', { world: '123' })
     ctx.commit({ type: 'hello', world: '123' })
+    ctx.commit('mutationWithUnionPayload', getStatus())
     ctx.commit('mutationWithoutPayload')
     ctx.commit({ type: 'mutationWithoutPayload' })
 
@@ -127,6 +137,10 @@ const actions: DefineActions<
     payload.qux
   },
 
+  actionWithUnionPayload(ctx, payload) {
+    ctx.commit('mutationWithUnionPayload', payload)
+  },
+
   actionWithoutPayload(ctx) {
     ctx.state.value
   }
@@ -141,6 +155,10 @@ const mutations: DefineMutations<FooMutations, FooState> = {
 
   hello(state, payload) {
     payload.world
+  },
+
+  mutationWithUnionPayload(state, payload) {
+    payload
   },
 
   mutationWithoutPayload(state) {


### PR DESCRIPTION
fixed: the following errors of defining types for functions with union type payloads.

## Union type payload

### Example

https://github.com/ktsn/vuex-type-helper/commit/4af9d98abbeec9f0e1cfa539aed8bfda0841dbea

```typescript
interface FooMutations {
  mutationWithUnionPayload: 'active' | 'inactive'
}
```

```typescript
const getStatus = (): 'active' | 'inactive' => {
  const statusArray = ['active', 'inactive'] as ['active', 'inactive']
  return statusArray[Math.floor(Math.random() * statusArray.length)]
}
ctx.commit('mutationWithUnionPayload', getStatus())
```

### Result

```
error TS2345: Argument of type '"mutationWithUnionPayload"' is not assignable to parameter of type 'BasePayload'.

ctx.commit('mutationWithUnionPayload', getStatus())
           ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Reason

```typescript
type PayloadArgs<T> = T extends void ? [] : [T]

// expected: ['active' | 'inactive']
// actually: ['active'] | ['inactive']
type payloadType = PayloadArgs<'active' | 'inactive'>
```

https://www.typescriptlang.org/play?ts=3.3.3#code/C4TwDgpgBACghiANgezgEwIICcDmBnAHgBUA+KAXiiKggA9gIA7NPKAN2QEs0oB+KANoBdKAC5BRIQCgpAelk1akAMYM04gQHI4qzmwiaoAHyibOjHcD0Hp8qJYCucRIhAbtu-ZpEmt5y9beUqCQUGAIKOhE4NCU8EiomLiEHlZexqb+ngYkUkA
